### PR TITLE
Create Installation Client

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 type GitHubAppConfig struct {
-	AppId          int
+	AppId          int64
 	PrivateKeyPath string
 	WebhookSecret  string
 }
@@ -15,7 +15,7 @@ var gitHubAppConfig *GitHubAppConfig
 func GetGitHubAppConig() GitHubAppConfig {
 	if gitHubAppConfig == nil {
 		gitHubAppConfig = &GitHubAppConfig{
-			AppId:          viper.GetInt("APP_ID"),
+			AppId:          viper.GetInt64("APP_ID"),
 			PrivateKeyPath: viper.GetString("PRIVATE_KEY_PATH"),
 			WebhookSecret:  viper.GetString("WEBHOOK_SECRET"),
 		}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -11,22 +11,45 @@ import (
 type Client = github.Client
 type Installation = github.Installation
 
+// Descriptions partially copied from
+// [palantor/go-githubapp](https://github.com/palantir/go-githubapp/blob/develop/githubapp/client_creator.go)
+
 // NewAppsClient returns a new github.Client that performs app authentication for
 // the GitHub App using its appId and private key.
 // The client can only be used for performing app-level operations that are not associated
 // with a specific installation.
 //
 // Authenticating as a GitHub App lets you do a couple of things:
-//  * You can retrieve high-level management information about your GitHub App.
-//  * You can request access tokens for an installation of the app.
+//   - You can retrieve high-level management information about your GitHub App.
+//   - You can request access tokens for an installation of the app.
 //
 // Tips for determining the arguments for this function:
-//  * the integration ID is listed as "ID" in the "About" section of the app's page
-//  * the key bytes must be a PEM-encoded PKCS1 or PKCS8 private key for the application
+//   - the integration ID is listed as "ID" in the "About" section of the app's page
+//   - the key bytes must be a PEM-encoded PKCS1 or PKCS8 private key for the application
 func NewAppsClient(config config.GitHubAppConfig) (*Client, error) {
 	tr := http.DefaultTransport
 
-	itr, err := ghinstallation.NewAppsTransportKeyFromFile(tr, int64(config.AppId), config.PrivateKeyPath)
+	itr, err := ghinstallation.NewAppsTransportKeyFromFile(tr, config.AppId, config.PrivateKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return github.NewClient(&http.Client{Transport: itr}), nil
+}
+
+// NewInstallationClient returns a new github.Client that performs app authentication for
+// the GitHub App using its appId, private key, and the given installation ID.
+// The client can be used to perform all operations that the GitHub App is configured for.
+//
+// Tips for determining the arguments for this function:
+//  * the integration ID is listed as "ID" in the "About" section of the app's page
+//  * the installation ID is the ID that is shown in the URL of https://{githubURL}/settings/installations/{#}
+//      (navigate to the "installations" page without the # and go to the app's page to see the number)
+//  * the key bytes must be a PEM-encoded PKCS1 or PKCS8 private key for the application
+func NewInstallationClient(config config.GitHubAppConfig, installationID int64) (*Client, error) {
+	tr := http.DefaultTransport
+
+	itr, err := ghinstallation.NewKeyFromFile(tr, config.AppId, installationID, config.PrivateKeyPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Adds `NewInstallationClient` to the `internal/client` package, allowing creation of GitHub App Installation Clients.
- Adds `GetInstallationClients` to the `AppsClient` process, allowing creation of Installation Clients for all current App Installations.

Closes #12
