### PR TITLE
Create Production Docker + Create Docker Bake File

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,13 @@
+group "default" {
+  targets = ["production"]
+}
+
+target "production" {
+  context = "."
+  dockerfile = "docker/prod.Dockerfile"
+  args = {
+    ALPINE_VERSION = "latest"
+    GO_VERSION = "1.24.1"
+  }
+  tags = ["zhangyumao:latest"]
+}

--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -1,0 +1,21 @@
+ARG ALPINE_VERSION="latest"
+ARG GO_VERSION="1.24.1"
+FROM golang:$GO_VERSION AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY config config
+COPY cmd cmd
+COPY apps apps
+COPY internal internal
+
+RUN CGO_ENABLED=0 GOOS=linux go build ./cmd/zhangyumao.go
+
+FROM alpine:$ALPINE_VERSION
+WORKDIR /root/
+COPY --from=builder /app/zhangyumao .
+EXPOSE 3000
+CMD ["./zhangyumao"]


### PR DESCRIPTION
- Adds `docker/prod.Dockerfile` for production Docker builds. (Closes #1)
- Adds `docker-bake.hcl` for declarative Docker images. (Closes #2)
